### PR TITLE
fix dB calculation in Meep scripts for waveguide mode converter and other improvements

### DIFF
--- a/waveguide_mode_converter/mode_converter_meep.py
+++ b/waveguide_mode_converter/mode_converter_meep.py
@@ -139,21 +139,21 @@ def mode_converter(design_fname: str):
     tran = np.abs(coeffs[0,:,0])**2 / input_flux
     tran_flux = np.array(mp.get_fluxes(tran_mon))
 
-    sparam_to_dB = lambda s: 20 * np.log10(s)
+    sparam2_to_dB = lambda s: 10 * np.log10(s)
 
     for idx,wvl in enumerate(wvls):
         print("refl:, {:.3f}, {:.6f}, {:.6f}".format(wvl,
                                                      refl[idx],
-                                                     sparam_to_dB(refl[idx])))
+                                                     sparam2_to_dB(refl[idx])))
 
-    print("worst-case reflectance (dB):, {:.6f}".format(sparam_to_dB(np.amax(refl))))
+    print("worst-case reflectance (dB):, {:.6f}".format(sparam2_to_dB(np.amax(refl))))
 
     for idx,wvl in enumerate(wvls):
         print("tran:, {:.3f}, {:.6f}, {:.6f}".format(wvl,
                                                      tran[idx],
-                                                     sparam_to_dB(tran[idx])))
+                                                     sparam2_to_dB(tran[idx])))
 
-    print("worst-case transmittance (dB):, {:.6f}".format(sparam_to_dB(np.amin(tran))))
+    print("worst-case transmittance (dB):, {:.6f}".format(sparam2_to_dB(np.amin(tran))))
 
     # compute the total reflectance (R) and transmittance (T) and their sum
     # the scattered power is thus 1-R-T


### PR DESCRIPTION
This PR fixes a bug in the computation of the reflectance and transmittance spectrum in dB units in the Meep scripts for the waveguide mode converter. To convert $R=|S_{11}|^2$ to dB involves $10\log_{10}{R}$ rather than $20\log_{10}{R}$ which meant that the previously reported values were 2X larger than their actual values. The plots below show the corrected spectrum for the topology-optimized designs. The values were are now comparable from those of the Ceviche designs.

The topology optimization script is also updated to use `subtracted_dft_fields` (rather than `norm_dft_fields`) introduced by NanoComp/meep#2271 after #25 was merged.

![optimized_mode_converter_x_mirror](https://user-images.githubusercontent.com/7152530/196742575-a7dfd937-00ee-44ae-b7c9-931478446384.png)
![optimized_mode_converter_no_mirror](https://user-images.githubusercontent.com/7152530/196742576-3a5d243f-4d0d-4496-9449-cf97ae943623.png)
