### PR TITLE
add more options to ruler.py

### DIFF
--- a/ruler/README.md
+++ b/ruler/README.md
@@ -1,17 +1,16 @@
-This is a small program for computing the minimum length scale of a design pattern given by topology optimization. The theoretical basis of the method lies in morphological transformations [1,2]. Some code is copied or adapted from the filter.py file in Meep [3].
+This is a small program for computing the minimum length scale of a design pattern given by topology optimization. The theoretical basis of the method for 2d and 3d design patterns lies in morphological transformations [1,2]. Some code is copied or adapted from the filter.py file in Meep [3].
 
-
-This method is outlined as follows.
-1. Normalize and binarize the design pattern. The input design pattern should be a 2d or 3d array.
-2. For a given filter radius, compute the difference between morphological opening and closing. This difference is a 2d or 3d array with the same shape as the design pattern.
-3. Count the number of interior nonzero pixels in the image of difference. The interior nonzero pixels are those surrounded by other nonzeros pixels, as shown in the figure below.
-4. Repeat Steps 2 and 3 for a series of filter radii, and seek the smallest filter radius at which an interior nonzero pixel emerges. The minimum length scale is considered as twice this filter radius.
+For a 1d design pattern, the code simply searches for the minimum length among all solid or void regions. For 2d or 3d design patterns, the method is outlined as follows.
+1. Normalize and binarize the design pattern. The input design pattern should be a 1d, 2d or 3d array.
+2. For a given circular structuring element that acts like a probe, compute the difference between the original pattern and the morphological opening. This difference is a 2d or 3d array with the same shape as the original pattern.
+3. Count the number of interior solid pixels in the image of difference. The interior solid pixels are the solid pixels surrounded by other solid pixels, as shown in the figure below.
+4. Using binary search, seek the smallest probe diameter at which an interior solid pixel emerges. This diameter is considered as the minimum length scale.
 
 ![image](https://github.com/mawc2019/ruler/blob/main/classification%20of%20pixels.jpg)
 
+The method has limitations due to discretization. The error can be the size of a few pixels. Therefore, a design pattern with its minimum length scale much larger than the pixel size is preferred. If the minimum length scale is comparable to the pixel size, the relative error may be large. In addition, if a design pattern contains a sharp corner that are neither small perturbations at the single-pixel level nor a portion of the pattern boundary, the minimum length scale should be zero or the size of one pixel, but the method gives a nonzero value that are proportional to but much larger than the size of one pixel.
 
-References
+References  
 [1] Linus Hägg and Eddie Wadbro, On minimum length scale control in density based topology optimization, Struct. Multidisc Optim. 58(3), 1015–1032 (2018).  
 [2] Rafael C. Gonzalez and Richard E. Woods, Digital Image Processing (Fourth Edition), Chapter 9 (Pearson, 2017).  
 [3] Alec Hammond et al., Adjoint solver in Meep: https://github.com/smartalecH/meep/blob/jax_rebase/python/adjoint/filters.py
-

--- a/ruler/ruler.py
+++ b/ruler/ruler.py
@@ -1,8 +1,22 @@
 import numpy as np
 
+solid_indicator = ['solid','solids','black','s','b','true','1',True,1]
+void_indicator = ['invert','void','white','v','w','false','0',True,0]
+minimum_indicator = ['minimum','minimal','min']
+both_indicator = ['both','two','2',2]
+
 def ruler_initialize(arr,phys_size,margin_size):
-    phys_size = np.array(phys_size)[np.squeeze(np.array(phys_size)).nonzero()] # physical size
-    assert np.squeeze(arr).ndim == len(phys_size), 'Input array and physical size must match!'
+    if isinstance(phys_size,np.ndarray):
+        phys_size = phys_size[np.squeeze(phys_size).nonzero()] # physical size
+    elif isinstance(phys_size,list) or isinstance(phys_size,tuple):
+        phys_size = np.array(phys_size)[np.squeeze(np.array(phys_size)).nonzero()]
+    elif isinstance(phys_size,float) or isinstance(phys_size,int):
+        phys_size = np.array([phys_size])
+    else:
+        AssertionError("Invalid format of the physical size.")
+
+    dims = len(phys_size) # dimension, should be 1, 2 or 3
+    assert np.squeeze(arr).ndim == dims, 'The physical size and the dimension of the input array do not match.'
 
     '''
     Users sometimes need to discard certain marginal regions, the withds of which are specified by margin_size.
@@ -10,79 +24,179 @@ def ruler_initialize(arr,phys_size,margin_size):
     and the third pair of elements, if there are, correspond to the third dimension.
     '''
     margin_size = np.reshape(margin_size,(-1,2))
+    if len(margin_size[:,0])>dims:
+        margin_size = margin_size[0:dims,:]
+        print('Warning: The row number of margin_size is larger than the dimension; The redundant row(s) will be discarded.')
     return phys_size, margin_size
 
-def minimum_length(arr,phys_size,margin_size=np.zeros((3,2)),threshold=0.5,proj_strength=10**6,len_arr=None):
+
+def minimum_length(arr,phys_size,margin_size=np.zeros((2,2)),measure_region='solid',pad_mode=None):
     '''
-    Compute the minimum length scale in a design pattern. The design pattern is arr.
-    The physical size is phys_size. The size of borders that need to be discarded is margin_size.
-    The binary values of pixels are thresholded by threshold.
-    The projection strength in some morphological operations is proj_strength.
+    Compute the minimum length scale in a design pattern. The design pattern is 'arr'.
+    The physical size is 'phys_size'. The size of borders that need to be discarded is 'margin_size'.
     '''
 
     phys_size, margin_size = ruler_initialize(arr,phys_size,margin_size)
+    shorter_entire_side = min(phys_size) # shorter side of the entire design region
+    all_pixel_sides = pixel_size(arr,phys_size)
+    shorter_pixel_side = min(all_pixel_sides) # shorter side of a pixel
     dims = len(phys_size) # dimension, should be 2 or 3
-    arr = binarize(arr,threshold)
+
+    '''
+    If all elements in the array are the same,
+    the code simply regards the shorter side of the entire pattern as the minimum length scale,
+    regardless of whether the pattern is solid or void.
+    '''
+    if len(np.unique(arr))==1:
+        return shorter_entire_side
+
+    '''
+    Design patterns with non-binary values are thresholded by 'binarize_threshold'.
+    The appearance of interior solid pixels is thresholded by 'interior_pixel_threshold'.
+    The projection strength in some morphological operations is 'proj_strength'.
+    '''
+    binarize_threshold, interior_pixel_threshold, proj_strength = 0.5, 0.5, 10**6
+    arr = binarize(arr,binarize_threshold)
     margin_number = margin(arr,phys_size,margin_size)
 
-    if np.array(len_arr).any(): # search the minimum length scale within a length array "len_arr"
-        radius_list = sorted(list(np.abs(len_arr)/2))
-        for radius in radius_list:
-            # difference between open and close
-            diff_image = abs(open_operator(arr,radius,phys_size,proj_strength)-close_operator(arr,radius,phys_size,proj_strength))
+    if isinstance(measure_region,str):
+        measure_region = measure_region.lower()
 
-            # number of interior pixels
-            pixel_in = in_pixel_count(diff_image,margin_number,dims,threshold)
+    if dims == 1:
+        arr = arr[margin_number[0,0]:len(arr)-margin_number[0,1]]
+        solid_min_length, void_min_length = minimum_length_1d(arr)
 
-            if pixel_in>0:
-                return radius*2
+        if measure_region in solid_indicator:
+            return solid_min_length*shorter_pixel_side
+        elif measure_region in void_indicator:
+            return void_min_length*shorter_pixel_side
+        elif measure_region in minimum_indicator:
+            return min(solid_min_length,void_min_length)*shorter_pixel_side
+        elif measure_region in both_indicator:
+            return solid_min_length*shorter_pixel_side, void_min_length*shorter_pixel_side
+        else:
+            AssertionError("Invalid argument for measure_region in the function minimum_length.")
 
-        print("The minimum length scale is not in this array of lengths.")
-        return
+    arr_shape = np.array(arr.shape)
+    pad_number = np.ceil(arr_shape/2).astype(int)
+    pad_width = *((int(np.ceil(s/2)), int(np.ceil(s/2))) for s in arr.shape),
+    if isinstance(pad_mode,str): pad_mode = pad_mode.lower()
 
-    else: # find the minimum length scale via binary search if "len_arr" is not provided
-        radius_ub = min(phys_size)/2 # maximum meaningful filter radius
-        diff_image_ub = abs(open_operator(arr,radius_ub,phys_size,proj_strength)-close_operator(arr,radius_ub,phys_size,proj_strength))
-        pixel_in_ub = in_pixel_count(diff_image_ub,margin_number,dims,threshold) 
+    if pad_mode==None or pad_mode=='edge':
+        arr_padded = np.pad(arr,pad_width=pad_width,mode='edge')
+    elif pad_mode in solid_indicator:
+        arr_padded = np.pad(arr,pad_width=pad_width,constant_values=1)
+    elif pad_mode in void_indicator:
+        arr_padded = np.pad(arr,pad_width=pad_width,constant_values=0)
+    else:
+        AssertionError("Invalid pad mode.")
 
-        if pixel_in_ub>0:
-            radii = [0,radius_ub/2,radius_ub]
-            while abs(radii[0]-radii[2])>min(pixel_size(arr,phys_size))/2:
-                radius = radii[1]
-                diff_image = abs(open_operator(arr,radius,phys_size,proj_strength)-close_operator(arr,radius,phys_size,proj_strength))
-                pixel_in = in_pixel_count(diff_image,margin_number,dims,threshold)
+    def interior_pixel_number(diameter,arr,margin_number,pad_number):
+        padded_shape = arr_shape+2*pad_number
+        padded_size = padded_shape*all_pixel_sides
+        diff_image = abs(heaviside_open(arr,diameter,padded_size,proj_strength)-arr)
+        return interior_solid_pixel_count(diff_image,margin_number,pad_number,dims)
 
-                if pixel_in==0: radii[0],radii[1] = radius,(radius+radii[2])/2 # radius is too small
-                else: radii[1],radii[2] = (radius+radii[0])/2,radius # radius is still large
+    if measure_region not in void_indicator:
+        min_len_solid_padded, status = search([shorter_pixel_side,shorter_entire_side],
+                                              min(pixel_size(arr,phys_size)),
+                                              lambda d: interior_pixel_number(d,arr_padded,margin_number,pad_number),
+                                              interior_pixel_threshold)
+        min_len_solid = min_len_solid_padded
 
-            return radii[2]*2
+        if pad_mode==None:
+            min_len_solid_unpadded, status = search([shorter_pixel_side,shorter_entire_side],
+                                                    min(pixel_size(arr,phys_size)),
+                                                    lambda d: interior_pixel_number(d,arr,margin_number,
+                                                                                    pad_number=np.zeros(dims)),
+                                                    interior_pixel_threshold)
 
-        else: # radius_ub is not a good starting radius of the binary search
-            radius_initial,pixel_in_initial = radius_ub/1.5,0 # decrease the radius
-            # search a starting radius until interior pixels emerge or the radius is unacceptably small
-            while pixel_in_initial==0 and radius_initial>min(pixel_size(arr,phys_size))/2:
-                radius_initial /= 1.5
-                diff_image_initial = \
-                abs(open_operator(arr,radius_initial,phys_size,proj_strength)-close_operator(arr,radius_initial,phys_size,proj_strength))
-                pixel_in_initial = in_pixel_count(diff_image_initial,margin_number,dims,threshold)
+            if abs(min_len_solid_unpadded-min_len_solid_padded)<shorter_entire_side/2:
+                min_len_solid = min_len_solid_unpadded
+            else:
+                min_len_solid = min_len_solid_unpadded/2
 
-            if pixel_in_initial>0: # start the binary search
-                radii = [0,radius_initial/2,radius_initial]
-                while abs(radii[0]-radii[2])>min(pixel_size(arr,phys_size))/2:
-                    radius = radii[1]
-                    diff_image = abs(open_operator(arr,radius,phys_size,proj_strength)-close_operator(arr,radius,phys_size,proj_strength))
-                    pixel_in = in_pixel_count(diff_image,margin_number,dims,threshold)
-                    if pixel_in==0: radii[0],radii[1] = radius,(radius+radii[2])/2
-                    else: radii[1],radii[2] = (radius+radii[0])/2,radius
-                return radii[2]*2
-            else: # pixel_in_initial==0, fail to find a starting radius
-                print("The minimum length scale is at least ", radius_ub*2)
-                return
+    if measure_region not in solid_indicator:
+        min_len_void_padded, status = search([shorter_pixel_side,shorter_entire_side],
+                                              min(pixel_size(arr,phys_size)),
+                                              lambda d: interior_pixel_number(d,1-arr_padded,margin_number,pad_number),
+                                              interior_pixel_threshold)
+        min_len_void = min_len_void_padded
 
-def proper_pad(arr,pad_to):
+        if pad_mode==None:
+            min_len_void_unpadded, status = search([shorter_pixel_side,shorter_entire_side],
+                                                    min(pixel_size(arr,phys_size)),
+                                                    lambda d: interior_pixel_number(d,1-arr,margin_number,
+                                                                                    pad_number=np.zeros(dims)),
+                                                    interior_pixel_threshold)
+
+            if abs(min_len_void_unpadded-min_len_void_padded)<shorter_entire_side/2:
+                min_len_void = min_len_void_unpadded
+            else:
+                min_len_void = min_len_void_unpadded/2
+  
+    if measure_region in solid_indicator:
+        return min_len_solid
+    elif measure_region in void_indicator:
+        return min_len_void
+    elif measure_region in minimum_indicator:
+        return min(min_len_solid,min_len_void)
+    elif measure_region in both_indicator:
+        return min_len_solid, min_len_void
+    else:
+        AssertionError("Invalid argument for measure_region in the function minimum_length.")
+
+
+def search(arg_range,arg_threshold,function,function_threshold): # binary search
+    args = [min(arg_range),(min(arg_range)+max(arg_range))/2,max(arg_range)]
+
+    if function(args[0])<function_threshold and function(args[2])>function_threshold:
+        while abs(args[0]-args[2])>arg_threshold:
+            arg = args[1]
+            if function(arg)<=function_threshold: args[0],args[1] = arg,(arg+args[2])/2 # radius is too small
+            else: args[1],args[2] = (arg+args[0])/2,arg # radius is still large
+        return args[2], True
+    elif function(args[0])<=function_threshold and function(args[2])<=function_threshold:
+        return args[2], False
+    elif function(args[0])>function_threshold and function(args[2])>function_threshold:
+        return args[0], False
+    else:
+        raise AssertionError("The function is not monotonically increasing.")
+
+def minimum_length_1d(arr):
+    arr = np.append(arr,1-arr[-1])
+    solid_lengths,void_lengths = [],[]
+    counter = 0
+
+    for idx in range(len(arr)-1):
+        counter += 1
+
+        if arr[idx] != arr[idx+1]:
+            if arr[idx] == 1:
+                solid_lengths.append(counter)
+            elif arr[idx] == 0:
+                void_lengths.append(counter)
+            else:
+                raise AssertionError("This array is not normalized.")
+            counter = 0
+
+    if len(solid_lengths)>0:
+        solid_min_length = min(solid_lengths)
+    else:
+        solid_min_length = 0
+
+    if len(void_lengths)>0:
+        void_min_length = min(void_lengths)
+    else:
+        void_min_length = 0
+
+    return solid_min_length, void_min_length
+
+
+def kernel_pad(arr,pad_to):
     '''
-    arr: Input array. Must be 2D.
-    pad_to: int. Total size to be padded to.
+    The input array is 'arr', which must be 2d or 3d.
+    The total size to be padded to is pad_to, which must be an integer.
     '''
     pad_size = pad_to-2*np.array(arr.shape)+1
 
@@ -105,102 +219,88 @@ def proper_pad(arr,pad_to):
 
         out = np.concatenate((upper,middle,lower),axis=2)
     else:
-        raise AssertionError("Function for this dimension is not implemented!")
+        raise AssertionError("The function for this dimension is not implemented.")
 
     return out
-            
-def simple_filter(arr,kernel):
+
+
+def convolution(arr,kernel):
     arr_sh = arr.shape
     npad = *((s, s) for s in arr_sh),
 
     # pad the kernel and the input array to avoid circular convolution and to ensure boundary conditions
-    kernel = proper_pad(kernel,np.array(arr_sh)*3)
-    kernel = np.squeeze(kernel) / np.sum(kernel) # Normalize the kernel
+    kernel = kernel_pad(kernel,np.array(arr_sh)*3)
+    kernel = np.squeeze(kernel) / np.sum(kernel) # normalize the kernel
     arr = np.pad(arr,pad_width=npad, mode='edge')
 
     K, A = np.fft.fftn(kernel), np.fft.fftn(arr) # transform to frequency domain for fast convolution
     arr_out = np.real(np.fft.ifftn(K * A)) # convolution
 
-    return center(arr_out,arr_sh) # Remove all the extra padding
+    return center(arr_out,arr_sh) # remove all the extra padding
 
-def cylindrical_filter(arr,radius,phys_size):
+
+def cylindrical_filter(arr,diameter,phys_size):
     arr = guarantee_2or3d(arr)
 
-    x_tick = np.arange(0,phys_size[0]/2,phys_size[0]/arr.shape[0])
-    y_tick = np.arange(0,phys_size[1]/2,phys_size[1]/arr.shape[1])
+    x_tick = np.arange(0,diameter/2,phys_size[0]/arr.shape[0])
+    y_tick = np.arange(0,diameter/2,phys_size[1]/arr.shape[1])
 
     if len(phys_size) == 2:
-        X, Y = np.meshgrid(x_tick, y_tick, sparse=True, indexing='ij') # grid over the entire design region
-        kernel = X**2+Y**2 < radius**2
+        X, Y = np.meshgrid(x_tick, y_tick, sparse=True, indexing='ij')
+        kernel = X**2+Y**2 < diameter**2/4
     elif len(phys_size) == 3:
         z_tick = np.arange(0,phys_size[2]/2,phys_size[2]/arr.shape[2])
         X, Y, Z = np.meshgrid(x_tick, y_tick, z_tick, sparse=True, indexing='ij')
-        kernel = X**2+Y**2+Z**2 < radius**2
+        kernel = X**2+Y**2+Z**2 < diameter**2/4
     else:
-        raise AssertionError("Function for this dimension is not implemented!")
+        raise AssertionError("The function for this dimension is not implemented.")
 
-    return simple_filter(arr,kernel) # Filter the input array
+    return convolution(arr,kernel)
 
-def heaviside_erosion(arr,radius,phys_size,proj_strength):
-    arr_hat = cylindrical_filter(arr,radius,phys_size)
+
+def heaviside_erode(arr,diameter,phys_size,proj_strength):
+    arr_hat = cylindrical_filter(arr,diameter,phys_size)
     return np.exp(-proj_strength*(1-arr_hat)) + np.exp(-proj_strength)*(1-arr_hat)
 
-def heaviside_dilation(arr,radius,phys_size,proj_strength):
-    arr_hat = cylindrical_filter(arr,radius,phys_size)
+
+def heaviside_dilate(arr,diameter,phys_size,proj_strength):
+    arr_hat = cylindrical_filter(arr,diameter,phys_size)
     return 1 - np.exp(-proj_strength*arr_hat) + np.exp(-proj_strength)*arr_hat
 
-def open_operator(arr,radius,phys_size,proj_strength):
-    # erosion and then dilation
 
-    he = heaviside_erosion(arr,radius,phys_size,proj_strength)
-    hdhe = heaviside_dilation(he,radius,phys_size,proj_strength)
+def heaviside_open(arr,diameter,phys_size,proj_strength):
+    # erosion and then dilation
+    he = heaviside_erode(arr,diameter,phys_size,proj_strength)
+    hdhe = heaviside_dilate(he,diameter,phys_size,proj_strength)
     return hdhe
 
-def close_operator(arr,radius,phys_size,proj_strength):
-    # dilation and then erosion
-
-    hd = heaviside_dilation(arr,radius,phys_size,proj_strength)
-    hehd = heaviside_erosion(hd,radius,phys_size,proj_strength)
-    return hehd
 
 def margin(arr,phys_size,margin_size):
-    # compute the numbers of pixels corresponding to the marginal widths
-
+    # compute the numbers of pixels corresponding to the marginal widths that need to be discarded
     arr = np.squeeze(arr)
-    margin_number = margin_size[0,:]/phys_size[0]*arr.shape[0]
+    margin_number = margin_size[0,:].reshape(1,2)/phys_size[0]*arr.shape[0]
 
-    for dim_idx in range(1,len(phys_size)):
+    for dim_idx in range(1,margin_size.shape[0]):
         margin_number = np.vstack((margin_number,margin_size[dim_idx,:]/phys_size[dim_idx]*arr.shape[dim_idx]))
+        
     margin_number = np.round(margin_number).astype(int) # numbers of pixels of marginal regions
 
-    assert (margin_number>=0).all(), 'Margin widths should be nonnegative!'
-    assert (np.array(arr.shape)-np.sum(margin_number,axis=1)>=3).all(), 'Too wide margin or too narrow design region!'
-
-    for ii in range(margin_number.shape[0]):
-        for jj in range(margin_number.shape[1]):
-            if margin_number[ii,jj]==0:
-                margin_number[ii,jj] = 1 # minimum possible margin_number
+    assert (margin_number>=0).all(), 'Margin widths should be nonnegative.'
+    assert (np.array(arr.shape)-np.sum(margin_number,axis=1)>=3).all(), 'Too wide margin or too narrow design region.'
 
     return margin_number
+
 
 def pixel_size(arr,phys_size):
     squeeze_shape = np.array(np.squeeze(arr).shape)
     return phys_size/squeeze_shape # sizes of a pixel along all finite-thickness directions
 
+
 def binarize(arr,demarcation=0.5):
     arr_normalized = (arr-min(arr.flatten()))/(max(arr.flatten())-min(arr.flatten())) # normalize the data of the array
-    arr_binarized = np.sign(arr_normalized-demarcation)/2+0.5 # binarize the data of the array with the threshold demarcation=0.5
+    arr_binarized = arr_normalized > demarcation # binarize the data of the array with the threshold 'demarcation'
     return arr_binarized
 
-def adjacency(index): # return adjacent indices
-    if len(index) == 2: # 2d
-        return [index[0],index[0],index[0],index[0]-1,index[0]+1],[index[1],index[1]-1,index[1]+1,index[1],index[1]]
-    elif len(index) == 3: # 3d
-        return [index[0],index[0],index[0],index[0],index[0],index[0]-1,index[0]+1],[
-            index[1],index[1],index[1],index[1]-1,index[1]+1,index[1],index[1]],[
-            index[2],index[2]-1,index[2]+1,index[2],index[2],index[2],index[2]]
-    else:
-        raise AssertionError("Function for this dimension is not implemented!")
 
 def guarantee_2or3d(arr):
     arr = np.squeeze(arr)
@@ -211,8 +311,9 @@ def guarantee_2or3d(arr):
     elif arr.ndim == 0:
         arr_out = np.expand_dims(arr, axis=(0, 1, 2))   
     else:
-        raise AssertionError("Too many dimensions!")
+        raise AssertionError("The input array has too many dimensions.")
     return arr_out
+
 
 def center(arr, newshape):
     '''Return the center newshape portion of the array.
@@ -227,24 +328,40 @@ def center(arr, newshape):
     myslice = [slice(startind[k], endind[k]) for k in range(len(endind))]
     return arr[tuple(myslice)]
 
-def in_pixel_count(arr,margin_number=np.ones((2,2),dtype=int),dims=2,threshold=0.5):
+
+def interior_solid_pixel_count(arr,margin_number=np.zeros((2,2),dtype=int),pad_number=np.zeros(2,dtype=int),dims=2):
     # return the number of interior pixels with nonzero values
 
-    pixel_int = 0 # initialize before counting
     arr = np.squeeze(arr)
+    margin_number, pad_number = margin_number.astype(int), pad_number.astype(int)
+
+    row_begin, row_end = margin_number[0,0]+1+pad_number[0], arr.shape[0]-margin_number[0,1]-1-pad_number[0]
+    column_begin,column_end = 1+pad_number[1], arr.shape[1]-1-pad_number[1]
+
+    if len(margin_number[:,0]) == 2:
+        column_begin,column_end = margin_number[1,0]+1+pad_number[1], arr.shape[1]-margin_number[1,1]-1-pad_number[1]
 
     if dims==2:
-        for ii in range(margin_number[0,0],arr.shape[0]-margin_number[0,1]):
-            for jj in range(margin_number[1,0],arr.shape[1]-margin_number[1,1]):
-                if (arr[adjacency([ii,jj])]>threshold).all(): # regard the value of a pixel as nonzero if it exceeds the threshold
-                    pixel_int += 1
-    elif dims==3:
-        for ii in range(margin_number[0,0],arr.shape[0]-margin_number[0,1]):
-            for jj in range(margin_number[1,0],arr.shape[1]-margin_number[1,1]):
-                for kk in range(margin_number[2,0],arr.shape[2]-margin_number[2,1]):
-                    if (arr[adjacency([ii,jj,kk])]>threshold).all():
-                        pixel_int += 1
-    else:
-        raise AssertionError("Function for this dimension is not implemented!")
+        # select interior solid pixels
+        selector = arr[row_begin:row_end,column_begin:column_end] * \
+                   arr[row_begin-1:row_end-1,column_begin:column_end] * arr[row_begin+1:row_end+1,column_begin:column_end] * \
+                   arr[row_begin:row_end,column_begin-1:column_end-1] * arr[row_begin:row_end,column_begin+1:column_end+1]
 
-    return pixel_int
+    elif dims==3:
+        if len(margin_number[:,0]) == 3:
+            page_begin, page_end = margin_number[2,0]+1+pad_number[2], arr.shape[2]-margin_number[2,1]-1-pad_number[2]
+        else:
+            page_begin, page_end = 1+pad_number[2], arr.shape[2]-1-pad_number[2]
+
+        selector = arr[row_begin:row_end,column_begin:column_end,page_begin:page_end] * \
+                   arr[row_begin-1:row_end-1,column_begin:column_end,page_begin:page_end] * \
+                   arr[row_begin+1:row_end+1,column_begin:column_end,page_begin:page_end] * \
+                   arr[row_begin:row_end,column_begin-1:column_end-1,page_begin:page_end] * \
+                   arr[row_begin:row_end,column_begin+1:column_end+1,page_begin:page_end] * \
+                   arr[row_begin:row_end,column_begin:column_end,page_begin-1:page_end-1] * \
+                   arr[row_begin:row_end,column_begin:column_end,page_begin+1:page_end+1]
+
+    else:
+        raise AssertionError("The function for this dimension is not implemented.")
+
+    return np.sum(selector)


### PR DESCRIPTION
This PR enables the options mentioned in https://github.com/NanoComp/photonics-opt-testbed/issues/36, but has some variation. By setting the argument `measure_region` in the function `minimum_length` as `solid`, `void`, `both`, or `min`, the code returns the minimum length scale of the solid region, the void region, both regions, and the minimum of the two.

This PR also support padding. One can set the the argument `pad_mode` in the function `minimum_length` as `solid`, `void`, or `edge`. The padding size is fixed as half of the size of the entire design pattern.

In addition, this PR supports the minimum length scale of 1d patterns. In this case, the code simply searches for the minimum length among all solid or void regions.

Closes #36