### PR TITLE
Tweak mode_converter_meep_opt.py

### DIFF
--- a/waveguide_mode_converter/mode_converter_meep_opt.py
+++ b/waveguide_mode_converter/mode_converter_meep_opt.py
@@ -63,9 +63,9 @@ nSi = 3.5
 Si = mp.Medium(index=nSi)
 
 design_region_size = mp.Vector3(dx, dy, 0)
-design_region_resolution = int(2 * resolution)
-Nx = int(design_region_size.x * design_region_resolution)
-Ny = int(design_region_size.y * design_region_resolution)
+design_region_resolution = 99.375
+Nx = int(round(design_region_size.x * design_region_resolution)) + 1
+Ny = int(round(design_region_size.y * design_region_resolution)) + 1
 
 # impose a bit "mask" of thickness equal to the filter radius
 # around the edges of the design region in order to prevent

--- a/waveguide_mode_converter/mode_converter_meep_opt.py
+++ b/waveguide_mode_converter/mode_converter_meep_opt.py
@@ -63,9 +63,10 @@ nSi = 3.5
 Si = mp.Medium(index=nSi)
 
 design_region_size = mp.Vector3(dx, dy, 0)
-design_region_resolution = 99.375
-Nx = int(round(design_region_size.x * design_region_resolution)) + 1
-Ny = int(round(design_region_size.y * design_region_resolution)) + 1
+design_region_resolution = int(2 * resolution)
+Nx = int(design_region_size.x * design_region_resolution)
+Ny = int(design_region_size.y * design_region_resolution)
+design_region_resolution = (Nx - 1) / design_region_size.x # correct for +1 factor in recent Meep
 
 # impose a bit "mask" of thickness equal to the filter radius
 # around the edges of the design region in order to prevent


### PR DESCRIPTION
The meep script [mode_converter_meep_opt.py](https://github.com/NanoComp/photonics-opt-testbed/blob/main/waveguide_mode_converter/mode_converter_meep_opt.py) is incompatible with the latest versions of meep because of the [correction](https://github.com/NanoComp/meep/pull/2504). To fix this issue, in this PR, the design resolution is decreased from 100 to 99.375, and the expressions of `Nx` and `Ny` are supplemented with `+1`.