### PR TITLE
Fix eigenmode coefficient objective function in Meep metagrating optimization

### DIFF
--- a/Metagrating3D/metagrating_meep_opt_1d.py
+++ b/Metagrating3D/metagrating_meep_opt_1d.py
@@ -1,5 +1,5 @@
 # This python script is for maximizing the diffraction efficiency of the m=+1 order
-# for a 3D metagrating with a 1D design.
+# for a 1D metagrating.
 
 import meep as mp
 import meep.adjoint as mpa
@@ -30,7 +30,7 @@ boundary_layers = [mp.PML(thickness=dpml,direction=mp.Y)]
 # periodic boundary conditions
 k_point = mp.Vector3()
 
-# plane of incidence is XZ
+# plane of incidence is XY
 P_pol = True
 src_cmpt = mp.Ex if P_pol else mp.Ez
 src_pt = mp.Vector3(0,-0.5*sy+dpml+0.5*dsub)
@@ -93,9 +93,20 @@ sim = mp.Simulation(resolution=resolution,
                     k_point=k_point,
                     eps_averaging=False)
 
-emc = mpa.EigenmodeCoefficient(sim,mp.Volume(center=mp.Vector3(0,0.5*sy-dpml),size=mp.Vector3(px,0)),
-                               mode=1,eig_parity = mp.EVEN_Z if P_pol else mp.ODD_Z,
-                               kpoint_func=lambda *not_used: kdiff)
+emc = mpa.EigenmodeCoefficient(
+    sim,
+    mp.Volume(
+        center=mp.Vector3(0, 0.5*sy - dpml),
+        size=mp.Vector3(px, 0)
+    ),
+    mode=1,
+    eig_parity=mp.EVEN_Z if P_pol else mp.ODD_Z,
+    kpoint_func=lambda *not_used: kdiff,
+    eig_vol=mp.Volume(
+        center=mp.Vector3(0, 0.5*sy - dpml),
+        size=mp.Vector3(1 / resolution, 0, 0)
+    )
+)
 ob_list = [emc]
 
 opt = mpa.OptimizationProblem(simulation=sim,objective_functions=J,objective_arguments=ob_list,

--- a/Metagrating3D/metagrating_meep_opt_2d.py
+++ b/Metagrating3D/metagrating_meep_opt_2d.py
@@ -1,5 +1,5 @@
 # This python script is for maximizing the diffraction efficiency of the m=+1 order
-# for a 3D metagrating with a 2D design.
+# for a 2D metagrating.
 
 import meep as mp
 import meep.adjoint as mpa
@@ -95,9 +95,20 @@ sim = mp.Simulation(resolution=resolution,
                     k_point=k_point,
                     eps_averaging=False)
 
-emc = mpa.EigenmodeCoefficient(sim,mp.Volume(center=mp.Vector3(0,0,0.5*sz-dpml),size=mp.Vector3(px,py,0)),
-                               mode=1,eig_parity = mp.EVEN_Y if P_pol else mp.ODD_Y,
-                               kpoint_func=lambda *not_used: kdiff)
+emc = mpa.EigenmodeCoefficient(
+    sim,
+    mp.Volume(
+        center=mp.Vector3(0, 0, 0.5*sz - dpml),
+        size=mp.Vector3(px, py, 0)
+    ),
+    mode=1,
+    eig_parity = mp.EVEN_Y if P_pol else mp.ODD_Y,
+    kpoint_func=lambda *not_used: kdiff,
+    eig_vol=mp.Volume(
+        center=mp.Vector3(0, 0, 0.5*sz - dpml),
+        size=mp.VEctor3(1 / resolution, 1 / resolution, 0)
+    )
+)
 ob_list = [emc]
 
 opt = mpa.OptimizationProblem(simulation=sim,objective_functions=J,objective_arguments=ob_list,


### PR DESCRIPTION
The Meep scripts used to optimize the metagrating currently require using a "hack" for `mpb.cpp` described in NanoComp/meep#2054 ([comment](https://github.com/NanoComp/meep/pull/2054#issuecomment-1126649464)). A fix was provided in NanoComp/meep#2285 which involved specifying the `eig_vol` parameter of the `meep.adjoint.EigenModeCoefficient` of the adjoint solver to have a length of one pixel in the periodic direction. This PR applies this fix to the two scripts.